### PR TITLE
Fix CLI and core bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .glide/
 vendor/
 main
+go-enc

--- a/README.md
+++ b/README.md
@@ -9,6 +9,75 @@ ENCs are used to track configuration across your infrastructure in a single unif
 * Choice of config format: JSON or YAML
 * Command-Line Interface
 
+## Usage
+Pick up the latest release binary for your system and try running with the help flag for 
+the available commands.
+
+Example output:
+
+```
+$ ./go-enc --help
+usage: go-enc [<flags>] <command> [<args> ...]
+
+CLI for interacting with YAML/JSON External Node Classifiers
+
+Flags:
+      --help                   Show context-sensitive help (also try --help-long and --help-man).
+  -g, --enc_glob="./*.yaml"    Glob pattern for matching ENC files
+  -e, --enc_name="production"  Name of the ENC you want to perform actions on
+
+Commands:
+  help [<command>...]
+    Show help.
+
+  nodegroup [<flags>] <action> <nodegroup>
+    Actions to do with nodegroups
+
+  node [<flags>] <action> <nodegroup> <node>
+    Actions to do with single node
+
+  nodes [<flags>] <add> <nodegroup> <nodes>...
+    Actions to do with single node
+
+  param <action> <nodegroup> <param_name> <param_value>
+    Actions for parameters
+
+  class <action> <nodegroup> <classname>
+    Actions for classes
+
+  class_param <action> <nodegroup> <class_name> <param_name> <param_value>
+    Actions for parameters
+
+  parent <nodegroup> <new_parent>
+    Set the parent value
+
+  environment <nodegroup> <new_environment>
+    Set the environment value
+```
+
+### Command Help
+You can also pass the help flag after adding your command.
+
+Example output:
+
+```
+$ ./go-enc nodegroup --help
+usage: go-enc nodegroup [<flags>] <action> <nodegroup>
+
+Actions to do with nodegroups
+
+Flags:
+      --help                   Show context-sensitive help (also try --help-long and --help-man).
+  -g, --enc_glob="./*.yaml"    Glob pattern for matching ENC files
+  -e, --enc_name="production"  Name of the ENC you want to perform actions on
+      --parent=""              Nodegoup parent
+
+Args:
+  <action>     add|remove|get
+  <nodegroup>  Nodegoup name
+```
+
+
 ## Development
 Go-ENC uses [dep](https://github.com/golang/dep) to manage dependencies.
 

--- a/cli/router.go
+++ b/cli/router.go
@@ -51,42 +51,44 @@ var (
 	classParamValue     = classParam.Arg("param_value", "Parameter value").Required().String()
 
 	parent          = app.Command("parent", "Set the parent value")
-	parentNodegroup = classParam.Arg("nodegroup", "Nodegoup name").Required().String()
+	parentNodegroup = parent.Arg("nodegroup", "Nodegoup name").Required().String()
 	parentVal       = parent.Arg("new_parent", "The new parent value (can be \"\" for none)").Required().String()
 
 	environment          = app.Command("environment", "Set the environment value")
-	environmentNodegroup = classParam.Arg("nodegroup", "Nodegoup name").Required().String()
+	environmentNodegroup = environment.Arg("nodegroup", "Nodegoup name").Required().String()
 	environmentVal       = environment.Arg("new_environment", "The new environment value (can be \"\" for none)").Required().String()
 
 	commandErr error
 )
 
 func NewCLI() {
-	kingpin.CommandLine.HelpFlag.Short('h')
+	arguments := kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	config := enc.NewConfig(*enc_glob)
-	working_enc, ok := config.ENCs[*enc_name]
+	_, ok := config.ENCs[*enc_name]
+	fmt.Printf("%#v", config.ENCs)
+
 	if !ok {
-		handleErr(fmt.Errorf("Chosen ENC doesn't exist: %s", enc_name))
+		handleErr(fmt.Errorf("Chosen ENC doesn't exist: %s", *enc_name))
 	}
 
-	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
-	case nodegroup.FullCommand():
-		nodegroupCommand(working_enc)
-	case node.FullCommand():
-		nodeCommand(working_enc)
-	case nodes.FullCommand():
-		nodesCommand(working_enc)
-	case param.FullCommand():
-		paramCommand(working_enc)
-	case class.FullCommand():
-		classCommand(working_enc)
-	case classParam.FullCommand():
-		classParamCommand(working_enc)
-	case parent.FullCommand():
-		parentCommand(working_enc)
-	case environment.FullCommand():
-		environmentCommand(working_enc)
+	switch arguments {
+	// case nodegroup.FullCommand():
+	// 	nodegroupCommand(working_enc)
+	// case node.FullCommand():
+	// 	nodeCommand(working_enc)
+	// case nodes.FullCommand():
+	// 	nodesCommand(working_enc)
+	// case param.FullCommand():
+	// 	paramCommand(working_enc)
+	// case class.FullCommand():
+	// 	classCommand(working_enc)
+	// case classParam.FullCommand():
+	// 	classParamCommand(working_enc)
+	// case parent.FullCommand():
+	// 	parentCommand(working_enc)
+	// case environment.FullCommand():
+	// 	environmentCommand(working_enc)
 	}
 
 	handleErr(commandErr)
@@ -105,64 +107,64 @@ func nodegroupCommand(working_enc *enc.ENC) {
 	}
 }
 
-func nodeCommand(working_enc *enc.ENC) {
-	switch *nodeAction {
-	case "add":
-		_, commandErr = working_enc.AddNode(*nodeNodegroup, *nodeNode)
-	case "get":
-		_, commandErr = working_enc.GetNode(*nodeNode)
-	case "remove":
-		_, commandErr = working_enc.RemoveNode(*nodeNodegroup, *nodeNode)
-	default:
-		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", node.FullCommand(), *nodeAction))
-	}
-}
+// func nodeCommand(working_enc *enc.ENC) {
+// 	switch *nodeAction {
+// 	case "add":
+// 		_, commandErr = working_enc.AddNode(*nodeNodegroup, *nodeNode)
+// 	case "get":
+// 		_, commandErr = working_enc.GetNode(*nodeNode)
+// 	case "remove":
+// 		_, commandErr = working_enc.RemoveNode(*nodeNodegroup, *nodeNode)
+// 	default:
+// 		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", node.FullCommand(), *nodeAction))
+// 	}
+// }
 
-func nodesCommand(working_enc *enc.ENC) {
-	_, commandErr = working_enc.AddNodes(*nodesNodegroup, *nodesNodes)
-}
+// func nodesCommand(working_enc *enc.ENC) {
+// 	_, commandErr = working_enc.AddNodes(*nodesNodegroup, *nodesNodes)
+// }
 
-func paramCommand(working_enc *enc.ENC) {
-	switch *paramAction {
-	case "add":
-		_, commandErr = working_enc.AddParameter(*paramNodegroup, *paramName, *paramValue)
-	case "set":
-		_, commandErr = working_enc.SetParameter(*paramNodegroup, *paramName, *paramValue)
-	case "remove":
-		_, commandErr = working_enc.RemoveParameter(*paramNodegroup, *paramName)
-	default:
-		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", param.FullCommand(), *paramAction))
-	}
-}
+// func paramCommand(working_enc *enc.ENC) {
+// 	switch *paramAction {
+// 	case "add":
+// 		_, commandErr = working_enc.AddParameter(*paramNodegroup, *paramName, *paramValue)
+// 	case "set":
+// 		_, commandErr = working_enc.SetParameter(*paramNodegroup, *paramName, *paramValue)
+// 	case "remove":
+// 		_, commandErr = working_enc.RemoveParameter(*paramNodegroup, *paramName)
+// 	default:
+// 		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", param.FullCommand(), *paramAction))
+// 	}
+// }
 
-func classCommand(working_enc *enc.ENC) {
-	switch *classAction {
-	case "add":
-		_, commandErr = working_enc.AddClass(*classNodegroup, *className)
-	case "remove":
-		_, commandErr = working_enc.AddClass(*classNodegroup, *className)
-	default:
-		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", class.FullCommand(), *classAction))
-	}
-}
+// func classCommand(working_enc *enc.ENC) {
+// 	switch *classAction {
+// 	case "add":
+// 		_, commandErr = working_enc.AddClass(*classNodegroup, *className)
+// 	case "remove":
+// 		_, commandErr = working_enc.AddClass(*classNodegroup, *className)
+// 	default:
+// 		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", class.FullCommand(), *classAction))
+// 	}
+// }
 
-func classParamCommand(working_enc *enc.ENC) {
-	switch *classParamAction {
-	case "add":
-		_, commandErr = working_enc.AddClassParameter(*classParamNodegroup, *classParamClass, *classParamName, *classParamValue)
-	case "set":
-		_, commandErr = working_enc.SetClassParameter(*classParamNodegroup, *classParamClass, *classParamName, *classParamValue)
-	case "remove":
-		_, commandErr = working_enc.RemoveClassParameter(*classParamNodegroup, *classParamClass, *classParamName)
-	default:
-		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", classParam.FullCommand(), *classParamAction))
-	}
-}
+// func classParamCommand(working_enc *enc.ENC) {
+// 	switch *classParamAction {
+// 	case "add":
+// 		_, commandErr = working_enc.AddClassParameter(*classParamNodegroup, *classParamClass, *classParamName, *classParamValue)
+// 	case "set":
+// 		_, commandErr = working_enc.SetClassParameter(*classParamNodegroup, *classParamClass, *classParamName, *classParamValue)
+// 	case "remove":
+// 		_, commandErr = working_enc.RemoveClassParameter(*classParamNodegroup, *classParamClass, *classParamName)
+// 	default:
+// 		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", classParam.FullCommand(), *classParamAction))
+// 	}
+// }
 
-func parentCommand(working_enc *enc.ENC) {
-	_, commandErr = working_enc.SetParent(*parentNodegroup, *parentVal)
-}
+// func parentCommand(working_enc *enc.ENC) {
+// 	_, commandErr = working_enc.SetParent(*parentNodegroup, *parentVal)
+// }
 
-func environmentCommand(working_enc *enc.ENC) {
-	_, commandErr = working_enc.SetEnvironment(*environmentNodegroup, *environmentVal)
-}
+// func environmentCommand(working_enc *enc.ENC) {
+// 	_, commandErr = working_enc.SetEnvironment(*environmentNodegroup, *environmentVal)
+// }

--- a/cli/router.go
+++ b/cli/router.go
@@ -65,33 +65,33 @@ func NewCLI() {
 	arguments := kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	config := enc.NewConfig(*enc_glob)
-	_, ok := config.ENCs[*enc_name]
-	fmt.Printf("%#v", config.ENCs)
-
+	working_enc, ok := config.ENCs[*enc_name]
 	if !ok {
 		handleErr(fmt.Errorf("Chosen ENC doesn't exist: %s", *enc_name))
 	}
 
 	switch arguments {
-	// case nodegroup.FullCommand():
-	// 	nodegroupCommand(working_enc)
-	// case node.FullCommand():
-	// 	nodeCommand(working_enc)
-	// case nodes.FullCommand():
-	// 	nodesCommand(working_enc)
-	// case param.FullCommand():
-	// 	paramCommand(working_enc)
-	// case class.FullCommand():
-	// 	classCommand(working_enc)
-	// case classParam.FullCommand():
-	// 	classParamCommand(working_enc)
-	// case parent.FullCommand():
-	// 	parentCommand(working_enc)
-	// case environment.FullCommand():
-	// 	environmentCommand(working_enc)
+	case nodegroup.FullCommand():
+		nodegroupCommand(working_enc)
+	case node.FullCommand():
+		nodeCommand(working_enc)
+	case nodes.FullCommand():
+		nodesCommand(working_enc)
+	case param.FullCommand():
+		paramCommand(working_enc)
+	case class.FullCommand():
+		classCommand(working_enc)
+	case classParam.FullCommand():
+		classParamCommand(working_enc)
+	case parent.FullCommand():
+		parentCommand(working_enc)
+	case environment.FullCommand():
+		environmentCommand(working_enc)
 	}
 
 	handleErr(commandErr)
+
+	config.WriteOutENC()
 }
 
 func nodegroupCommand(working_enc *enc.ENC) {
@@ -107,64 +107,64 @@ func nodegroupCommand(working_enc *enc.ENC) {
 	}
 }
 
-// func nodeCommand(working_enc *enc.ENC) {
-// 	switch *nodeAction {
-// 	case "add":
-// 		_, commandErr = working_enc.AddNode(*nodeNodegroup, *nodeNode)
-// 	case "get":
-// 		_, commandErr = working_enc.GetNode(*nodeNode)
-// 	case "remove":
-// 		_, commandErr = working_enc.RemoveNode(*nodeNodegroup, *nodeNode)
-// 	default:
-// 		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", node.FullCommand(), *nodeAction))
-// 	}
-// }
+func nodeCommand(working_enc *enc.ENC) {
+	switch *nodeAction {
+	case "add":
+		_, commandErr = working_enc.AddNode(*nodeNodegroup, *nodeNode)
+	case "get":
+		_, commandErr = working_enc.GetNode(*nodeNode)
+	case "remove":
+		_, commandErr = working_enc.RemoveNode(*nodeNodegroup, *nodeNode)
+	default:
+		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", node.FullCommand(), *nodeAction))
+	}
+}
 
-// func nodesCommand(working_enc *enc.ENC) {
-// 	_, commandErr = working_enc.AddNodes(*nodesNodegroup, *nodesNodes)
-// }
+func nodesCommand(working_enc *enc.ENC) {
+	_, commandErr = working_enc.AddNodes(*nodesNodegroup, *nodesNodes)
+}
 
-// func paramCommand(working_enc *enc.ENC) {
-// 	switch *paramAction {
-// 	case "add":
-// 		_, commandErr = working_enc.AddParameter(*paramNodegroup, *paramName, *paramValue)
-// 	case "set":
-// 		_, commandErr = working_enc.SetParameter(*paramNodegroup, *paramName, *paramValue)
-// 	case "remove":
-// 		_, commandErr = working_enc.RemoveParameter(*paramNodegroup, *paramName)
-// 	default:
-// 		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", param.FullCommand(), *paramAction))
-// 	}
-// }
+func paramCommand(working_enc *enc.ENC) {
+	switch *paramAction {
+	case "add":
+		_, commandErr = working_enc.AddParameter(*paramNodegroup, *paramName, *paramValue)
+	case "set":
+		_, commandErr = working_enc.SetParameter(*paramNodegroup, *paramName, *paramValue)
+	case "remove":
+		_, commandErr = working_enc.RemoveParameter(*paramNodegroup, *paramName)
+	default:
+		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", param.FullCommand(), *paramAction))
+	}
+}
 
-// func classCommand(working_enc *enc.ENC) {
-// 	switch *classAction {
-// 	case "add":
-// 		_, commandErr = working_enc.AddClass(*classNodegroup, *className)
-// 	case "remove":
-// 		_, commandErr = working_enc.AddClass(*classNodegroup, *className)
-// 	default:
-// 		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", class.FullCommand(), *classAction))
-// 	}
-// }
+func classCommand(working_enc *enc.ENC) {
+	switch *classAction {
+	case "add":
+		_, commandErr = working_enc.AddClass(*classNodegroup, *className)
+	case "remove":
+		_, commandErr = working_enc.AddClass(*classNodegroup, *className)
+	default:
+		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", class.FullCommand(), *classAction))
+	}
+}
 
-// func classParamCommand(working_enc *enc.ENC) {
-// 	switch *classParamAction {
-// 	case "add":
-// 		_, commandErr = working_enc.AddClassParameter(*classParamNodegroup, *classParamClass, *classParamName, *classParamValue)
-// 	case "set":
-// 		_, commandErr = working_enc.SetClassParameter(*classParamNodegroup, *classParamClass, *classParamName, *classParamValue)
-// 	case "remove":
-// 		_, commandErr = working_enc.RemoveClassParameter(*classParamNodegroup, *classParamClass, *classParamName)
-// 	default:
-// 		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", classParam.FullCommand(), *classParamAction))
-// 	}
-// }
+func classParamCommand(working_enc *enc.ENC) {
+	switch *classParamAction {
+	case "add":
+		_, commandErr = working_enc.AddClassParameter(*classParamNodegroup, *classParamClass, *classParamName, *classParamValue)
+	case "set":
+		_, commandErr = working_enc.SetClassParameter(*classParamNodegroup, *classParamClass, *classParamName, *classParamValue)
+	case "remove":
+		_, commandErr = working_enc.RemoveClassParameter(*classParamNodegroup, *classParamClass, *classParamName)
+	default:
+		handleErr(fmt.Errorf("Invalid action for command: [command: %s ; action: %s]", classParam.FullCommand(), *classParamAction))
+	}
+}
 
-// func parentCommand(working_enc *enc.ENC) {
-// 	_, commandErr = working_enc.SetParent(*parentNodegroup, *parentVal)
-// }
+func parentCommand(working_enc *enc.ENC) {
+	_, commandErr = working_enc.SetParent(*parentNodegroup, *parentVal)
+}
 
-// func environmentCommand(working_enc *enc.ENC) {
-// 	_, commandErr = working_enc.SetEnvironment(*environmentNodegroup, *environmentVal)
-// }
+func environmentCommand(working_enc *enc.ENC) {
+	_, commandErr = working_enc.SetEnvironment(*environmentNodegroup, *environmentVal)
+}

--- a/enc/config.go
+++ b/enc/config.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"fmt"
+
 	"gopkg.in/yaml.v2"
 )
 
@@ -18,6 +20,7 @@ type Config struct {
 
 // NewConfig generates a new ENC from the config. One ENC for each file matched by the glob pattern
 func NewConfig(globPatttern string) *Config {
+	fmt.Printf("%#v", globPatttern)
 	matchingFiles, err := filepath.Glob(globPatttern)
 	errCheck(err)
 

--- a/enc/config.go
+++ b/enc/config.go
@@ -35,7 +35,8 @@ func NewConfig(globPatttern string) *Config {
 
 	for _, file := range matchingFiles {
 		var enc *ENC
-		switch extension := strings.ToLower(filepath.Ext(file)); extension {
+		extension := strings.ToLower(filepath.Ext(file))
+		switch extension {
 		case ".json":
 			enc = NewENC("json")
 			c.processJSONFile(file, enc)
@@ -47,6 +48,7 @@ func NewConfig(globPatttern string) *Config {
 		}
 
 		filename := filepath.Base(file)
+		filename = filename[0 : len(filename)-len(extension)]
 		c.ENCs[filename] = enc
 	}
 

--- a/enc/config.go
+++ b/enc/config.go
@@ -124,8 +124,11 @@ func (c *Config) processRawENC(rawEnc map[string]interface{}, enc *ENC) {
 			classes = make(map[string]interface{}, 0)
 		}
 
-		if nodes, ok = attrs["nodes"].([]string); !ok {
-			nodes = make([]string, 0)
+		nodes = make([]string, 0)
+		if attrs["nodes"] != nil {
+			for _, node := range attrs["nodes"].([]interface{}) {
+				nodes = append(nodes, node.(string))
+			}
 		}
 
 		if parameters, ok = attrs["parameters"].(map[string]interface{}); !ok {

--- a/enc/config.go
+++ b/enc/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -51,6 +52,28 @@ func NewConfig(globPatttern string) *Config {
 	}
 
 	return c
+}
+
+func (c *Config) WriteOutENC() {
+	for _, current_enc := range c.ENCs {
+		file, fileErr := os.Create(current_enc.FileName)
+		defer file.Close()
+		errCheck(fileErr)
+
+		var encContents []byte
+		var marshalErr error
+
+		switch extension := strings.ToLower(filepath.Ext(current_enc.FileName)); extension {
+		case ".json":
+			encContents, marshalErr = json.Marshal(current_enc.Nodegroups)
+		case ".yaml", ".yml":
+			encContents, marshalErr = yaml.Marshal(current_enc.Nodegroups)
+		}
+		errCheck(marshalErr)
+
+		file.Write(encContents)
+		file.Sync()
+	}
 }
 
 func (c *Config) processJSONFile(filepath string, enc *ENC) {

--- a/enc/config.go
+++ b/enc/config.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"fmt"
-
 	"gopkg.in/yaml.v2"
 )
 
@@ -20,7 +18,6 @@ type Config struct {
 
 // NewConfig generates a new ENC from the config. One ENC for each file matched by the glob pattern
 func NewConfig(globPatttern string) *Config {
-	fmt.Printf("%#v", globPatttern)
 	matchingFiles, err := filepath.Glob(globPatttern)
 	errCheck(err)
 
@@ -38,16 +35,17 @@ func NewConfig(globPatttern string) *Config {
 		extension := strings.ToLower(filepath.Ext(file))
 		switch extension {
 		case ".json":
-			enc = NewENC("json")
+			enc = NewENC("json", file)
 			c.processJSONFile(file, enc)
 		case ".yaml", ".yml":
-			enc = NewENC("yaml")
+			enc = NewENC("yaml", file)
 			c.processYAMLFile(file, enc)
 		default:
 			panic(errors.New("Unrecognised file extension, expecting: json|yaml"))
 		}
 
 		filename := filepath.Base(file)
+		// Strip extension from filename
 		filename = filename[0 : len(filename)-len(extension)]
 		c.ENCs[filename] = enc
 	}

--- a/enc/config_test.go
+++ b/enc/config_test.go
@@ -194,10 +194,11 @@ func testNewJSONConfig(t *testing.T) {
     },
     Nodes:      trie.New(),
     ConfigType: "json",
+    FileName:   jsonFile,
   }
 
   gotJSONConfig := NewConfig(jsonFile)
-  assert.Equal(wantEnc, *gotJSONConfig.ENCs["enc_test-json_data.json"])
+  assert.Equal(wantEnc, *gotJSONConfig.ENCs["enc_test-json_data"])
 }
 
 func testNewYAMLConfig(t *testing.T) {
@@ -258,8 +259,9 @@ func testNewYAMLConfig(t *testing.T) {
     },
     Nodes:      trie.New(),
     ConfigType: "yaml",
+    FileName:   yamlFile,
   }
 
   gotYAMLConfig := NewConfig(yamlFile)
-  assert.Equal(wantEnc, *gotYAMLConfig.ENCs["enc_test-yaml_data.yaml"])
+  assert.Equal(wantEnc, *gotYAMLConfig.ENCs["enc_test-yaml_data"])
 }

--- a/enc/enc.go
+++ b/enc/enc.go
@@ -22,14 +22,16 @@ type ENC struct {
 	Nodegroups map[string]Nodegroup
 	Nodes      *trie.Trie
 	ConfigType string
+	FileName   string
 }
 
 // NewENC initialises a new ENC
-func NewENC(configType string) *ENC {
+func NewENC(configType string, fileName string) *ENC {
 	return &ENC{
 		Nodegroups: map[string]Nodegroup{},
 		Nodes:      trie.New(),
 		ConfigType: configType,
+		FileName:   fileName,
 	}
 }
 

--- a/enc/enc.go
+++ b/enc/enc.go
@@ -10,11 +10,11 @@ import (
 
 // Nodegroup represents groups of nodes and meta information about them
 type Nodegroup struct {
-	Parent      string                 `json:"parent" yaml:"parent"`
-	Classes     map[string]interface{} `json:"classes" yaml:"classes"`
-	Nodes       []string               `json:"nodes" yaml:"nodes"`
-	Parameters  map[string]interface{} `json:"parameters" yaml:"parameters"`
-	Environment string                 `json:"environment" yaml:"environment"`
+	Parent      string                 `json:"parent,omitempty" yaml:"parent,omitempty"`
+	Classes     map[string]interface{} `json:"classes,omitempty" yaml:"classes,omitempty"`
+	Nodes       []string               `json:"nodes,omitempty" yaml:"nodes,omitempty"`
+	Parameters  map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Environment string                 `json:"environment,omitempty" yaml:"environment,omitempty"`
 }
 
 // ENC represents the entire structure of the External Node Classifier

--- a/enc/enc_test.go
+++ b/enc/enc_test.go
@@ -11,12 +11,13 @@ func TestNewENC(t *testing.T) {
 	assert := assert.New(t)
 	nodesTrie := trie.New()
 	want := ENC{
+		FileName:   "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{},
 		Nodes:      nodesTrie,
 		ConfigType: "json",
 	}
 
-	got := NewENC("json")
+	got := NewENC("json", "/tmp/test.json")
 	assert.Equal(want, *got)
 }
 
@@ -32,6 +33,7 @@ func TestAddNodegroup(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -39,7 +41,7 @@ func TestAddNodegroup(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotNodegroup, nodegroupErr := gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 
 	assert.Equal(wantEnc, *gotEnc)
@@ -59,12 +61,13 @@ func TestRemoveNodegroup(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName:   "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{},
 		Nodes:      trie.New(),
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotNodegroup, nodegroupErr := gotEnc.RemoveNodegroup("wantNodegroup")
 
@@ -85,6 +88,7 @@ func TestGetNodegroup(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -92,7 +96,7 @@ func TestGetNodegroup(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 
 	gotNodegroup, nodegroupErr := gotEnc.GetNodegroup("wantNodegroup")
@@ -116,6 +120,7 @@ func TestAddNode(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -123,7 +128,7 @@ func TestAddNode(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 
 	gotNodegroup, nodegroupErr := gotEnc.AddNode("wantNodegroup", "node-0001")
@@ -151,6 +156,7 @@ func TestAddNodes(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -158,7 +164,7 @@ func TestAddNodes(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 
 	gotNodegroup, nodegroupErr := gotEnc.AddNodes("wantNodegroup", []string{"node-0001", "node-0002"})
@@ -199,6 +205,7 @@ func TestGetParentChain(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup":   wantNodegroup,
 			"subNodegroup":    subNodegroup,
@@ -210,7 +217,7 @@ func TestGetParentChain(t *testing.T) {
 
 	wantChain := []string{"subSubNodegroup", "subNodegroup", "wantNodegroup"}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
@@ -257,6 +264,7 @@ func TestGetLongestChain(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup":   wantNodegroup,
 			"subNodegroup":    subNodegroup,
@@ -266,7 +274,7 @@ func TestGetLongestChain(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
@@ -312,6 +320,7 @@ func TestRemoveNode(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup":   wantNodegroup,
 			"subNodegroup":    subNodegroup,
@@ -321,7 +330,7 @@ func TestRemoveNode(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
@@ -352,6 +361,7 @@ func TestAddParameter(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -359,7 +369,7 @@ func TestAddParameter(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddParameter("wantNodegroup", "test_param", "test_value")
 
@@ -381,6 +391,7 @@ func TestRemoveParameter(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -388,7 +399,7 @@ func TestRemoveParameter(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddParameter("wantNodegroup", "test_param", "test_value")
 	gotEnc.RemoveParameter("wantNodegroup", "test_param")
@@ -413,6 +424,7 @@ func TestAddClass(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -420,7 +432,7 @@ func TestAddClass(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddClass("wantNodegroup", "test_class")
 
@@ -442,6 +454,7 @@ func TestRemoveClass(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -449,7 +462,7 @@ func TestRemoveClass(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddClass("wantNodegroup", "test_class")
 	gotEnc.RemoveClass("wantNodegroup", "test_class")
@@ -476,6 +489,7 @@ func TestAddClassParameter(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -483,7 +497,7 @@ func TestAddClassParameter(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddClass("wantNodegroup", "test_class")
 	gotEnc.AddClassParameter("wantNodegroup", "test_class", "test_class_param", "test_value")
@@ -508,6 +522,7 @@ func TestRemoveClassParameter(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -515,7 +530,7 @@ func TestRemoveClassParameter(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddClass("wantNodegroup", "test_class")
 	gotEnc.AddClassParameter("wantNodegroup", "test_class", "test_class_param", "test_value")
@@ -547,6 +562,7 @@ func TestSetParent(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"test_parent":   parentNodegroup,
 			"wantNodegroup": wantNodegroup,
@@ -555,7 +571,7 @@ func TestSetParent(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddNodegroup("test_parent", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotNodegroup, gotErr := gotEnc.SetParent("wantNodegroup", "test_parent")
@@ -580,6 +596,7 @@ func TestSetEnvironment(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -587,7 +604,7 @@ func TestSetEnvironment(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotNodegroup, gotErr := gotEnc.SetEnvironment("wantNodegroup", "test_env")
 
@@ -652,6 +669,7 @@ func TestGetNode(t *testing.T) {
 	}
 
 	wantEnc := ENC{
+		FileName: "/tmp/test.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup":   wantNodegroup,
 			"subNodegroup":    subNodegroup,
@@ -687,7 +705,7 @@ func TestGetNode(t *testing.T) {
 		Environment: "env_two",
 	}
 
-	gotEnc := NewENC("json")
+	gotEnc := NewENC("json", "/tmp/test.json")
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}), []string{}, make(map[string]interface{}))
 	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup", make(map[string]interface{}), []string{}, make(map[string]interface{}))
 	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup", make(map[string]interface{}), []string{}, make(map[string]interface{}))


### PR DESCRIPTION
Fixed:

* Naming collisions in argument variable names for the CLI
* Individual ENC names including the extension of the file
* Unmarshalling not properly extracting nodes for nodegroups

Added:

* Ability to write to disk
* After CLI execution, changes will be written to disk