### PR TITLE
Inter cluster nodegroups

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ pipeline:
       - /go/bin/dep ensure
       - go test -v enc/*    # Verbose tests
     when:
-      event: [push, tag, pull_request]
+      event: [push, tag]
   make_package:
     image: golang:${GO_VERSION}
     environment:

--- a/enc/config.go
+++ b/enc/config.go
@@ -11,18 +11,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var (
-	globalConfig *Config
-)
-
 // Config stores the configuration for our ENC
 type Config struct {
 	ENCs        map[string]*ENC
 	GlobPattern string
-}
-
-func GetGlobalConfig() *Config {
-	return globalConfig
 }
 
 // NewConfig generates a new ENC from the config. One ENC for each file matched by the glob pattern
@@ -63,11 +55,9 @@ func NewConfig(globPatttern string) *Config {
 		filename = filename[0 : len(filename)-len(extension)]
 		encNodeTracker[filename] = nodegroupNodes
 		enc.Name = filename
+		enc.ConfigLink = c
 		c.ENCs[filename] = enc
 	}
-
-	// Record global config for inter-cluster nodegroup-grabbing
-	globalConfig = c
 
 	// Adding all nodes here so they can properly track inter-cluster parents
 	for encName, nodegroupNodes := range encNodeTracker {

--- a/enc/config.go
+++ b/enc/config.go
@@ -115,13 +115,14 @@ func (c *Config) processYAMLFile(filepath string, enc *ENC) {
 }
 
 func (c *Config) processRawENC(rawEnc map[string]interface{}, enc *ENC) {
+	nodegroupNodes := make(map[string][]string, 0)
+
 	for nodegroup, attributes := range rawEnc {
 		attrs := attributes.(map[string]interface{})
 
 		var (
 			parent     string
 			classes    map[string]interface{}
-			nodes      []string
 			parameters map[string]interface{}
 			ok         bool
 		)
@@ -134,13 +135,6 @@ func (c *Config) processRawENC(rawEnc map[string]interface{}, enc *ENC) {
 			classes = make(map[string]interface{}, 0)
 		}
 
-		nodes = make([]string, 0)
-		if attrs["nodes"] != nil {
-			for _, node := range attrs["nodes"].([]interface{}) {
-				nodes = append(nodes, node.(string))
-			}
-		}
-
 		if parameters, ok = attrs["parameters"].(map[string]interface{}); !ok {
 			parameters = make(map[string]interface{}, 0)
 		}
@@ -149,7 +143,18 @@ func (c *Config) processRawENC(rawEnc map[string]interface{}, enc *ENC) {
 			nodegroup,
 			parent,
 			classes,
-			nodes,
+			make([]string, 0),
 			parameters)
+
+		nodegroupNodes[nodegroup] = make([]string, 0)
+		if attrs["nodes"] != nil {
+			for _, node := range attrs["nodes"].([]interface{}) {
+				nodegroupNodes[nodegroup] = append(nodegroupNodes[nodegroup], node.(string))
+			}
+		}
+	}
+
+	for nodegroup, nodes := range nodegroupNodes {
+		enc.AddNodes(nodegroup, nodes)
 	}
 }

--- a/enc/config.go
+++ b/enc/config.go
@@ -11,10 +11,18 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+var (
+	globalConfig *Config
+)
+
 // Config stores the configuration for our ENC
 type Config struct {
 	ENCs        map[string]*ENC
 	GlobPattern string
+}
+
+func GetGlobalConfig() *Config {
+	return globalConfig
 }
 
 // NewConfig generates a new ENC from the config. One ENC for each file matched by the glob pattern
@@ -50,6 +58,8 @@ func NewConfig(globPatttern string) *Config {
 		filename = filename[0 : len(filename)-len(extension)]
 		c.ENCs[filename] = enc
 	}
+
+	globalConfig = c
 
 	return c
 }

--- a/enc/config_test.go
+++ b/enc/config_test.go
@@ -140,6 +140,7 @@ func testNewJSONConfig(t *testing.T) {
   assert := assert.New(t)
 
   wantEnc := ENC{
+    Name: "enc_test-json_data",
     Nodegroups: map[string]Nodegroup{
       "globals": Nodegroup{
         Classes: map[string]interface{}{
@@ -198,13 +199,17 @@ func testNewJSONConfig(t *testing.T) {
   }
 
   gotJSONConfig := NewConfig(jsonFile)
-  assert.Equal(wantEnc, *gotJSONConfig.ENCs["enc_test-json_data"])
+
+  gotENC := gotJSONConfig.ENCs["enc_test-json_data"]
+  gotENC.ConfigLink = nil
+  assert.Equal(wantEnc, *gotENC)
 }
 
 func testNewYAMLConfig(t *testing.T) {
   assert := assert.New(t)
 
   wantEnc := ENC{
+    Name: "enc_test-yaml_data",
     Nodegroups: map[string]Nodegroup{
       "globals": Nodegroup{
         Classes: map[string]interface{}{
@@ -263,5 +268,7 @@ func testNewYAMLConfig(t *testing.T) {
   }
 
   gotYAMLConfig := NewConfig(yamlFile)
-  assert.Equal(wantEnc, *gotYAMLConfig.ENCs["enc_test-yaml_data"])
+  gotENC := gotYAMLConfig.ENCs["enc_test-yaml_data"]
+  gotENC.ConfigLink = nil
+  assert.Equal(wantEnc, *gotENC)
 }

--- a/enc/enc.go
+++ b/enc/enc.go
@@ -69,16 +69,39 @@ func (enc *ENC) RemoveNodegroup(name string) (*Nodegroup, error) {
 		return &nodegroup, nil
 	}
 
-	return &Nodegroup{}, errors.New("Nodegroup does not exist")
+	return &Nodegroup{}, fmt.Errorf("Nodegroup does not exist: %s", name)
 }
 
 // GetNodegroup retrieves a nodegroup by name
 func (enc *ENC) GetNodegroup(nodegroupName string) (*Nodegroup, error) {
-	if val, ok := enc.Nodegroups[nodegroupName]; ok {
+	config := GetGlobalConfig()
+
+	var (
+		nodegroup         string
+		cluster           string
+		clusterNodegroups map[string]Nodegroup
+	)
+
+	if config != nil {
+		if strings.Contains(nodegroupName, "@") {
+			nodegroupSplit := strings.Split(nodegroupName, "@")
+			nodegroup, cluster = nodegroupSplit[0], nodegroupSplit[1]
+			fmt.Println("No config")
+		} else {
+			nodegroup, cluster = nodegroupName, "production"
+			fmt.Println("Config")
+		}
+
+		clusterNodegroups = config.ENCs[cluster].Nodegroups
+	} else {
+		clusterNodegroups, nodegroup = enc.Nodegroups, nodegroupName
+	}
+
+	if val, ok := clusterNodegroups[nodegroup]; ok {
 		return &val, nil
 	}
 
-	return &Nodegroup{}, errors.New("Nodegroup does not exist")
+	return &Nodegroup{}, fmt.Errorf("Nodegroup does not exist: %s", nodegroupName)
 }
 
 // AddNode adds a single node to a nodegroup

--- a/enc/enc.go
+++ b/enc/enc.go
@@ -223,8 +223,12 @@ func (enc *ENC) GetChains(nodeName string) ([]string, error) {
 }
 
 func (enc *ENC) travelChain(root *trie.Node, currentChain string) []string {
-	var emptyChain []string
+	var trackerChain []string
 	for letter, node := range root.Children() {
+		if len(root.Children()) > 1 && string(letter) == "\x00" {
+			continue
+		}
+
 		newChain := currentChain
 		if string(letter) != "\x00" {
 			newChain = newChain + string(letter)
@@ -232,13 +236,13 @@ func (enc *ENC) travelChain(root *trie.Node, currentChain string) []string {
 
 		if len(node.Children()) > 0 {
 			childChains := enc.travelChain(node, newChain)
-			emptyChain = append(emptyChain, childChains...)
+			trackerChain = append(trackerChain, childChains...)
 		} else {
-			emptyChain = append(emptyChain, newChain)
+			trackerChain = append(trackerChain, newChain)
 		}
 	}
 
-	return emptyChain
+	return trackerChain
 }
 
 // mergeNodegroups merges two nodegroups, preserving values exclusive to ngA and overwriting with

--- a/enc/enc.go
+++ b/enc/enc.go
@@ -213,6 +213,7 @@ func (enc *ENC) GetNode(nodeName string) (*Nodegroup, error) {
 	return masterNodegroup, nil
 }
 
+// Get all possible parents for a node from the trie
 func (enc *ENC) GetChains(nodeName string) ([]string, error) {
 	root, ok := enc.Nodes.Find(nodeName)
 	if !ok {

--- a/enc/enc_test.go
+++ b/enc/enc_test.go
@@ -314,7 +314,7 @@ func TestGetLongestChain(t *testing.T) {
 	// We aren't testing the trie package
 	wantEnc.Nodes = gotEnc.Nodes
 
-	assert.Equal("node-0001-wantNodegroup@enc_test-json_data-subNodegroup@enc_test-json_data", gotEnc.getLongestChain("node-0001"))
+	assert.Equal("node-0001$$wantNodegroup@enc_test-json_data$$subNodegroup@enc_test-json_data", gotEnc.getLongestChain("node-0001"))
 	assert.Equal(wantEnc, *gotEnc)
 }
 
@@ -374,11 +374,11 @@ func TestRemoveNode(t *testing.T) {
 	// Because of the nature of a trie, we only want the key to disappear if
 	// it has no children. wantNodegroup has one child so should remain
 	gotEnc.RemoveNode("wantNodegroup", "node-0001")
-	assert.NotNil(gotEnc.Nodes.Find("node-0001-wantNodegroup@enc_test-json_data"))
+	assert.NotNil(gotEnc.Nodes.Find("node-0001$$wantNodegroup@enc_test-json_data"))
 
 	// subNodegroup on the other hand has no children so will be removed
 	gotEnc.RemoveNode("subNodegroup", "node-0001")
-	assert.Nil(gotEnc.Nodes.Find("node-0001-wantNodegroup@enc_test-json_data-subNodegroup@enc_test-json_data"))
+	assert.Nil(gotEnc.Nodes.Find("node-0001$$wantNodegroup@enc_test-json_data$$subNodegroup@enc_test-json_data"))
 
 	// We aren't testing the trie package
 	wantEnc.Nodes = gotEnc.Nodes
@@ -697,7 +697,7 @@ func TestGetNode(t *testing.T) {
 	}
 
 	subNodegroup := Nodegroup{
-		Parent: "wantNodegroup",
+		Parent: "wantNodegroup@enc_test-json_data",
 		Classes: map[string]interface{}{
 			"test_class": map[string]interface{}{
 				"unique_test": "I've never been overriden",
@@ -714,7 +714,7 @@ func TestGetNode(t *testing.T) {
 	}
 
 	subSubNodegroup := Nodegroup{
-		Parent: "subNodegroup",
+		Parent: "subNodegroup@enc_test-json_data",
 		Classes: map[string]interface{}{
 			"test_class": map[string]interface{}{
 				"override_me": "I'm legit",
@@ -744,7 +744,7 @@ func TestGetNode(t *testing.T) {
 	}
 
 	wantNode := Nodegroup{
-		Parent: "subNodegroup",
+		Parent: "",
 		Classes: map[string]interface{}{
 			"test_class": map[string]interface{}{
 				"override_me": "I'm legit",
@@ -760,9 +760,7 @@ func TestGetNode(t *testing.T) {
 				"unique_test": "I've never been overriden",
 			},
 		},
-		Nodes: []string{
-			"node-0001",
-		},
+		Nodes: nil,
 		Parameters: map[string]interface{}{
 			"test_param": "test_value",
 		},
@@ -772,8 +770,8 @@ func TestGetNode(t *testing.T) {
 	gotEnc := conf.ENCs["enc_test-json_data"]
 	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}), []string{}, make(map[string]interface{}))
-	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup", make(map[string]interface{}), []string{}, make(map[string]interface{}))
-	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup", make(map[string]interface{}), []string{}, make(map[string]interface{}))
+	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup@enc_test-json_data", make(map[string]interface{}), []string{}, make(map[string]interface{}))
+	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup@enc_test-json_data", make(map[string]interface{}), []string{}, make(map[string]interface{}))
 
 	gotEnc.AddNode("subSubNodegroup", "node-0001")
 

--- a/enc/enc_test.go
+++ b/enc/enc_test.go
@@ -7,17 +7,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	conf *Config
+)
+
+func init() {
+	conf = NewConfig("/tmp/enc_test-json_data.json")
+}
+
 func TestNewENC(t *testing.T) {
 	assert := assert.New(t)
 	nodesTrie := trie.New()
 	want := ENC{
-		FileName:   "/tmp/test.json",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{},
 		Nodes:      nodesTrie,
 		ConfigType: "json",
 	}
 
-	got := NewENC("json", "/tmp/test.json")
+	got := NewENC("json", "/tmp/enc_test-json_data.json")
 	assert.Equal(want, *got)
 }
 
@@ -33,7 +41,9 @@ func TestAddNodegroup(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -41,7 +51,8 @@ func TestAddNodegroup(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotNodegroup, nodegroupErr := gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 
 	assert.Equal(wantEnc, *gotEnc)
@@ -61,13 +72,16 @@ func TestRemoveNodegroup(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName:   "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{},
 		Nodes:      trie.New(),
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotNodegroup, nodegroupErr := gotEnc.RemoveNodegroup("wantNodegroup")
 
@@ -88,7 +102,9 @@ func TestGetNodegroup(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -96,7 +112,8 @@ func TestGetNodegroup(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 
 	gotNodegroup, nodegroupErr := gotEnc.GetNodegroup("wantNodegroup")
@@ -120,7 +137,9 @@ func TestAddNode(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -128,7 +147,8 @@ func TestAddNode(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 
 	gotNodegroup, nodegroupErr := gotEnc.AddNode("wantNodegroup", "node-0001")
@@ -156,7 +176,9 @@ func TestAddNodes(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -164,7 +186,8 @@ func TestAddNodes(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 
 	gotNodegroup, nodegroupErr := gotEnc.AddNodes("wantNodegroup", []string{"node-0001", "node-0002"})
@@ -189,7 +212,7 @@ func TestGetParentChain(t *testing.T) {
 	}
 
 	subNodegroup := Nodegroup{
-		Parent:      "wantNodegroup",
+		Parent:      "wantNodegroup@enc_test-json_data",
 		Classes:     make(map[string]interface{}, 0),
 		Nodes:       []string{},
 		Parameters:  make(map[string]interface{}, 0),
@@ -197,7 +220,7 @@ func TestGetParentChain(t *testing.T) {
 	}
 
 	subSubNodegroup := Nodegroup{
-		Parent:      "subNodegroup",
+		Parent:      "subNodegroup@enc_test-json_data",
 		Classes:     make(map[string]interface{}, 0),
 		Nodes:       []string{},
 		Parameters:  make(map[string]interface{}, 0),
@@ -205,7 +228,9 @@ func TestGetParentChain(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup":   wantNodegroup,
 			"subNodegroup":    subNodegroup,
@@ -215,12 +240,13 @@ func TestGetParentChain(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	wantChain := []string{"subSubNodegroup", "subNodegroup", "wantNodegroup"}
+	wantChain := []string{"subSubNodegroup@enc_test-json_data", "subNodegroup@enc_test-json_data", "wantNodegroup@enc_test-json_data"}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	conf.ENCs["enc_test-json_data"].Nodegroups = make(map[string]Nodegroup, 0)
+	gotEnc := conf.ENCs["enc_test-json_data"]
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
-	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
-	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
+	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup@enc_test-json_data", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
+	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup@enc_test-json_data", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 
 	gotChain := gotEnc.getParentChain("subSubNodegroup")
 
@@ -246,7 +272,7 @@ func TestGetLongestChain(t *testing.T) {
 	}
 
 	subNodegroup := Nodegroup{
-		Parent:  "wantNodegroup",
+		Parent:  "wantNodegroup@enc_test-json_data",
 		Classes: make(map[string]interface{}, 0),
 		Nodes: []string{
 			"node-0001",
@@ -256,7 +282,7 @@ func TestGetLongestChain(t *testing.T) {
 	}
 
 	subSubNodegroup := Nodegroup{
-		Parent:      "subNodegroup",
+		Parent:      "subNodegroup@enc_test-json_data",
 		Classes:     make(map[string]interface{}, 0),
 		Nodes:       []string{},
 		Parameters:  make(map[string]interface{}, 0),
@@ -264,7 +290,9 @@ func TestGetLongestChain(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup":   wantNodegroup,
 			"subNodegroup":    subNodegroup,
@@ -274,17 +302,19 @@ func TestGetLongestChain(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
+	gotEnc.Name = "enc_test-json_data"
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
-	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
-	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
+	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup@enc_test-json_data", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
+	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup@enc_test-json_data", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddNode("wantNodegroup", "node-0001")
 	gotEnc.AddNode("subNodegroup", "node-0001")
 
 	// We aren't testing the trie package
 	wantEnc.Nodes = gotEnc.Nodes
 
-	assert.Equal("node-0001-subNodegroup-wantNodegroup", gotEnc.getLongestChain("node-0001"))
+	assert.Equal("node-0001-wantNodegroup@enc_test-json_data-subNodegroup@enc_test-json_data", gotEnc.getLongestChain("node-0001"))
 	assert.Equal(wantEnc, *gotEnc)
 }
 
@@ -302,7 +332,7 @@ func TestRemoveNode(t *testing.T) {
 	}
 
 	subNodegroup := Nodegroup{
-		Parent:  "wantNodegroup",
+		Parent:  "wantNodegroup@enc_test-json_data",
 		Classes: make(map[string]interface{}, 0),
 		Nodes: []string{
 			"node-0001",
@@ -312,7 +342,7 @@ func TestRemoveNode(t *testing.T) {
 	}
 
 	subSubNodegroup := Nodegroup{
-		Parent:      "subNodegroup",
+		Parent:      "subNodegroup@enc_test-json_data",
 		Classes:     make(map[string]interface{}, 0),
 		Nodes:       []string{},
 		Parameters:  make(map[string]interface{}, 0),
@@ -320,7 +350,9 @@ func TestRemoveNode(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup":   wantNodegroup,
 			"subNodegroup":    subNodegroup,
@@ -330,21 +362,27 @@ func TestRemoveNode(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
+	gotEnc.Name = "enc_test-json_data"
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
-	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
-	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
+	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup@enc_test-json_data", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
+	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup@enc_test-json_data", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddNode("wantNodegroup", "node-0001")
 	gotEnc.AddNode("subNodegroup", "node-0001")
 
+	// Because of the nature of a trie, we only want the key to disappear if
+	// it has no children. wantNodegroup has one child so should remain
 	gotEnc.RemoveNode("wantNodegroup", "node-0001")
+	assert.NotNil(gotEnc.Nodes.Find("node-0001-wantNodegroup@enc_test-json_data"))
+
+	// subNodegroup on the other hand has no children so will be removed
+	gotEnc.RemoveNode("subNodegroup", "node-0001")
+	assert.Nil(gotEnc.Nodes.Find("node-0001-wantNodegroup@enc_test-json_data-subNodegroup@enc_test-json_data"))
 
 	// We aren't testing the trie package
 	wantEnc.Nodes = gotEnc.Nodes
-
 	assert.Equal(wantEnc, *gotEnc)
-	assert.Nil(gotEnc.Nodes.Find("node-0001-wantNodegroup"))
-	assert.NotNil(gotEnc.Nodes.Find("node-0001-subNodegroup-wantNodegroup"))
 }
 
 func TestAddParameter(t *testing.T) {
@@ -361,7 +399,9 @@ func TestAddParameter(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -369,7 +409,8 @@ func TestAddParameter(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddParameter("wantNodegroup", "test_param", "test_value")
 
@@ -391,7 +432,9 @@ func TestRemoveParameter(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -399,7 +442,8 @@ func TestRemoveParameter(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddParameter("wantNodegroup", "test_param", "test_value")
 	gotEnc.RemoveParameter("wantNodegroup", "test_param")
@@ -424,7 +468,9 @@ func TestAddClass(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -432,7 +478,8 @@ func TestAddClass(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddClass("wantNodegroup", "test_class")
 
@@ -454,7 +501,9 @@ func TestRemoveClass(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -462,7 +511,8 @@ func TestRemoveClass(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddClass("wantNodegroup", "test_class")
 	gotEnc.RemoveClass("wantNodegroup", "test_class")
@@ -489,7 +539,9 @@ func TestAddClassParameter(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -497,7 +549,8 @@ func TestAddClassParameter(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddClass("wantNodegroup", "test_class")
 	gotEnc.AddClassParameter("wantNodegroup", "test_class", "test_class_param", "test_value")
@@ -522,7 +575,9 @@ func TestRemoveClassParameter(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -530,7 +585,8 @@ func TestRemoveClassParameter(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddClass("wantNodegroup", "test_class")
 	gotEnc.AddClassParameter("wantNodegroup", "test_class", "test_class_param", "test_value")
@@ -562,7 +618,9 @@ func TestSetParent(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"test_parent":   parentNodegroup,
 			"wantNodegroup": wantNodegroup,
@@ -571,7 +629,8 @@ func TestSetParent(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotEnc.AddNodegroup("test_parent", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotNodegroup, gotErr := gotEnc.SetParent("wantNodegroup", "test_parent")
@@ -596,7 +655,9 @@ func TestSetEnvironment(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup": wantNodegroup,
 		},
@@ -604,7 +665,8 @@ func TestSetEnvironment(t *testing.T) {
 		ConfigType: "json",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}, 0), []string{}, make(map[string]interface{}, 0))
 	gotNodegroup, gotErr := gotEnc.SetEnvironment("wantNodegroup", "test_env")
 
@@ -669,7 +731,9 @@ func TestGetNode(t *testing.T) {
 	}
 
 	wantEnc := ENC{
-		FileName: "/tmp/test.json",
+		ConfigLink: conf,
+		Name:       "enc_test-json_data",
+		FileName:   "/tmp/enc_test-json_data.json",
 		Nodegroups: map[string]Nodegroup{
 			"wantNodegroup":   wantNodegroup,
 			"subNodegroup":    subNodegroup,
@@ -705,7 +769,8 @@ func TestGetNode(t *testing.T) {
 		Environment: "env_two",
 	}
 
-	gotEnc := NewENC("json", "/tmp/test.json")
+	gotEnc := conf.ENCs["enc_test-json_data"]
+	gotEnc.Nodegroups = make(map[string]Nodegroup, 0)
 	gotEnc.AddNodegroup("wantNodegroup", "", make(map[string]interface{}), []string{}, make(map[string]interface{}))
 	gotEnc.AddNodegroup("subNodegroup", "wantNodegroup", make(map[string]interface{}), []string{}, make(map[string]interface{}))
 	gotEnc.AddNodegroup("subSubNodegroup", "subNodegroup", make(map[string]interface{}), []string{}, make(map[string]interface{}))


### PR DESCRIPTION
Added ability to reference nodegroups from other clusters and have them included when getting the definition of a node. e.g. you could have `globals@globals` -> `website@production` -> `webserver-0001` and the node will inherit all the way from the globals nodegroup in another cluster.

These changes rely heavily on using the Trie datastructure for the nodes in each ENC which involved tweaking all of the tests and adding a reference to the Config object whenever an ENC is created.